### PR TITLE
Add no-js class and lang attribute to html

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,7 @@
 layout: compress
 ---
 <!DOCTYPE html>
-<html>
+<html class="no-js" lang="en">
 {% include head.html %}
 	<body>
 		{% include skip-link.html %}


### PR DESCRIPTION
This should fix some foundation js components when js is disabled
The lang attribute should improve the indexing by search engines