### PR TITLE
Menu logo

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,11 @@
+{% assign front = false %}
+{% if page.url == "/" or page.url == "/de" %}
+{% assign front = true %}
+{% endif %}
 <header class="navigation">
 
     <div class="navrow">
-        <div class="logo hidden">
+        <div class="{% if front %}hidden front {% endif %}logo">
             {{ site.title }}
         </div>
 

--- a/_js/menu.js
+++ b/_js/menu.js
@@ -2,9 +2,9 @@
 $(document).ready(function () {
     $(window).scroll(function () {
         if ($(window).scrollTop() > 100) {
-            $('.logo').removeClass('hidden');
+            $('.logo.front').removeClass('hidden');
         } else {
-            $('.logo').addClass('hidden');
+            $('.logo.front').addClass('hidden');
         }
     });
     $('.mobile-toggle').click(function () {


### PR DESCRIPTION
Fixes #2 

I added some logic to `_include/header.html` to determine if the rendered page is the front-page or not.
If it is, it adds the classes `hidden` and `front` to the logo `div`.

Please check if the values I check on `page.url` are sufficient to determine all cases.
Maybe you need to add or switch to `index.html` and `de/index.html` depending on your jekyll setup.